### PR TITLE
Fix "no" -> "on" typo in installation.md

### DIFF
--- a/site/content/documentation/starting/installation.md
+++ b/site/content/documentation/starting/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-subTitle: Install Insomnia no any platform
+subTitle: Install Insomnia on any platform
 slug: installation
 menu:
     docs:


### PR DESCRIPTION
Was cruising the site/docs while downloading, and noticed the typo. Came here to fix it. 